### PR TITLE
Use extraConfig, remove Document group reference

### DIFF
--- a/_Setup/snapshot.json
+++ b/_Setup/snapshot.json
@@ -1648,7 +1648,10 @@
           "modelActivenessState": "ACTIVE",
           "modelDisplayName": "ART",
           "searchEventFilter": "(originLevel1=~'MainSearch' OR originLevel1=~'Listing')",
-          "viewEventFilter": ""
+          "viewEventFilter": "",
+          "extraConfig": {
+            "filterOutEmptyQueries": false
+          }
         },
         "parents": {},
         "resourceName": "ART_OZqnzo"
@@ -1659,9 +1662,7 @@
             "--conf",
             "coveo.drill.automaticSelection.fields.0.field=ec_category",
             "--conf",
-            "coveo.drill.automaticSelection.fields.0.strategy=taxonomy_coverage",
-            "--conf",
-            "coveo.drill.indexContent.documentGroupId=1639593647500"
+            "coveo.drill.automaticSelection.fields.0.strategy=taxonomy_coverage"
           ],
           "commonFilter": "",
           "engineId": "facetsense",
@@ -1671,7 +1672,15 @@
           "intervalUnit": "WEEK",
           "modelActivenessState": "ACTIVE",
           "modelDisplayName": "DNE",
-          "searchEventFilter": ""
+          "searchEventFilter": "",
+          "extraConfig": {
+            "automaticSelection": {
+              "fields": [{
+                "field": "ec_category",
+                "strategy": "taxonomy_coverage"
+              }]
+            }
+          }
         },
         "parents": {},
         "resourceName": "DNE_qnlZNJ"


### PR DESCRIPTION
Two things:

1. command line parameters are no longer supported (have not been for a while ish). We need `extraConfig` now. I adapted.
2. Document group id cannot be anything, it actually yeids invalid model, we found tons of those for partner org in prod. I remove the reference to it. It's an invalid model anyway.

Note that once I merge this: https://coveord.atlassian.net/browse/REVEAL-6803 the DNE model with the payload I suggest will work well in the admin ui. For now it won't (but it already wasn't!)